### PR TITLE
Feature/jira trigger helper

### DIFF
--- a/force-app/main/default/classes/JiraTriggerHelper.cls
+++ b/force-app/main/default/classes/JiraTriggerHelper.cls
@@ -16,20 +16,7 @@ public with sharing class JiraTriggerHelper {
 			}
 		}
 
-		// Simple bulkification by looping through each project
-		for (Jira_Project__c project : projectsToProcess) {
-			// Enqueue the callout
-			JiraCalloutQueueable callout = new JiraCalloutQueueable(
-				project.Id,
-				project.Project_Name__c,
-				project.Project_Key__c,
-				project.Description__c
-			);
-
-			if (!Test.isRunningTest()) {
-				System.enqueueJob(callout);
-			}
-		}
+		enqueueJob(new JiraCalloutQueueable(projectsToProcess, 20));
 	}
 
 	/**
@@ -45,5 +32,35 @@ public with sharing class JiraTriggerHelper {
 	 */
 	public static void processIssueAfterInsert(List<Jira_Issue__c> newIssues) {
 		// Your implementation goes here
+		List<Jira_Issue__c> issuesToProcess = new List<Jira_Issue__c>();
+		for (Jira_Issue__c newIssue : newIssues) {
+			if (String.isBlank(newIssue.Issue_Key__c) && !String.isBlank(newIssue.Project_Key__c)) {
+				issuesToProcess.add(newIssue);
+			}
+		}
+
+		enqueueJob(new JiraCalloutQueueable(issuesToProcess, 20));
+	}
+
+	/*
+	 * Utilitary method to enqueue Queueable job
+	 * @param JiraCalloutQueuable Queueable job to queue
+	 */
+	private static void enqueueJob(JiraCalloutQueueable callout) {
+		if (!Test.isRunningTest()) {
+			try {
+				// Queue job if within queueable governor limits
+				if (Limits.getQueueableJobs() < Limits.getLimitQueueableJobs()) {
+					// Queue job passing list of projects, to avoid hitting exceptions by queueing within loops, and batch size for chaining purposes
+					System.enqueueJob(callout);
+					return;
+				}
+				throw new JiraAPIService.JiraException(
+					'Queueable jobs limit has been reached, the callouts to the Jira API could not be queued.'
+				);
+			} catch (Exception e) {
+				CustomLogger.insertLog(e, 'ERROR');
+			}
+		}
 	}
 }

--- a/force-app/main/default/classes/JiraTriggerHelper.cls
+++ b/force-app/main/default/classes/JiraTriggerHelper.cls
@@ -22,13 +22,6 @@ public with sharing class JiraTriggerHelper {
 	/**
 	 * Process Jira_Issue__c records after insert
 	 * @param newIssues List of newly inserted Jira_Issue__c records
-	 *
-	 * TODO: Implement this method to process new Jira issues
-	 * The method should:
-	 * 1. Filter out issues that already have a Jira issue key
-	 * 2. Ensure the Project_Key__c field is not blank
-	 * 3. Create a JiraCalloutQueueable for each issue and enqueue it
-	 * 4. Don't enqueue if Test.isRunningTest() is true
 	 */
 	public static void processIssueAfterInsert(List<Jira_Issue__c> newIssues) {
 		// Your implementation goes here

--- a/force-app/main/default/classes/JiraTriggerHelper.cls-meta.xml
+++ b/force-app/main/default/classes/JiraTriggerHelper.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<ApexClass xmlns="https://soap.sforce.com/2006/04/metadata">
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
- Implemented `JiraTriggerHelper.cls` with logic to make callouts to the Jira API (v3) to create issues and projects after inserting them in Salesforce.
- Meet error handling and separation of concerns requirements while also leveraging abstraction through the utility method `JiraTriggerHelper.enqueueJob()` to avoid repetitive code.